### PR TITLE
Fix verbose commit messages

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -48,17 +48,18 @@ export function getGitCommitFoldingRanges(document: vscode.TextDocument, context
 }
 
 export function getGitCommitSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentSymbol[]> {
+    const kindDescriptions = new Map([
+        [GitChunkKind.Subject, "Subject Line"],
+        [GitChunkKind.Paragraph, "Paragraph"],
+        [GitChunkKind.Comment, "Comment"],
+        [GitChunkKind.Diff, "Diff"],
+    ]);
+
     return getDocumentChunks(document)
         .map(({range, kind}) => {
-            const text = document.getText(range);
-            if (kind === GitChunkKind.Subject) {
-                return new vscode.DocumentSymbol("Subject Line", text, vscode.SymbolKind.Object, range, range);
-            } else if (kind === GitChunkKind.Paragraph) {
-                return new vscode.DocumentSymbol("Paragraph", text, vscode.SymbolKind.Object, range, range);
-            } else if (kind === GitChunkKind.Comment) {
-                return new vscode.DocumentSymbol("Comment", text, vscode.SymbolKind.Object, range, range);
-            } else if (kind === GitChunkKind.Diff) {
-                return new vscode.DocumentSymbol("Diff", text, vscode.SymbolKind.Object, range, range);
+            const description = kindDescriptions.get(kind);
+            if (description != null) {
+                return new vscode.DocumentSymbol(description, document.getText(range), vscode.SymbolKind.Object, range, range);
             }
         })
         .filter(e => e !== undefined) as vscode.DocumentSymbol[];


### PR DESCRIPTION
When using [the verbose option of git commit](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--v), the commit message contains a unified diff at the end. That diff is currently also formatted as if it is part of the commit message. Correct is to not format it at all.

So, without this fix this commit message
```diff
Add code kind
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch fix_verbose_commit_messages
# Changes to be committed:
#	modified:   src/formatter.ts
#
# Untracked files:
#	package-lock.json
#
# ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.
diff --git a/src/formatter.ts b/src/formatter.ts
index 6eecada..8543008 100644
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -15,6 +15,7 @@ enum GitChunkKind {
     Paragraph = 1,
     Comment = 2,
     Blank = 3,
+    Code = 4,
 }
```

should have not been changed at all but it wrongly was formatted like this:

```diff
Add code kind
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch fix_verbose_commit_messages
# Changes to be committed:
#	modified:   src/formatter.ts
#
# Untracked files:
#	package-lock.json
#
# ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.
diff --git a/src/formatter.ts b/src/formatter.ts index 6eecada..8543008
100644 --- a/src/formatter.ts +++ b/src/formatter.ts @@ -15,6 +15,7 @@
enum GitChunkKind { Paragraph = 1, Comment = 2, Blank = 3, + Code = 4, }
```

Git itself detects the diff by looking for a comment with the cut line `------------------------ >8 ------------------------`. There might be some more comment lines below that. But everything after that is considered by git as the diff.